### PR TITLE
[#61] Fix error if item has non-existing groups

### DIFF
--- a/src/filtering.test.tsx
+++ b/src/filtering.test.tsx
@@ -1,4 +1,4 @@
-import {blue, expensive, large, medium, red, small} from '../test/test-data';
+import {blue, expensive, green, large, medium, red, small} from '../test/test-data';
 import {describe, test} from '@jest/globals';
 import {TestDataFiltering} from '../test/test-data-types';
 import {createFilterData, getNames, jsToSchema, jsxToHtml, testFiltering} from '../test/test-utils';
@@ -233,5 +233,52 @@ describe('Test Tiltering', function () {
             'available': ['true'],
         }));
         expect(result.filteredItems.map((item) => item.data.element.id)).toEqual(['item-1']);
+    });
+
+    test('Filtering Item with a non existing group.', function () {
+        const schema = jsToSchema({
+            groups: {
+                color: ['red', 'blue'],
+            },
+            items: [{
+                name: 'item-1',
+                groups: {
+                    color: [red],
+                    size: [small],
+                },
+            }],
+        });
+        const filtering = new Filtering(schema);
+
+        expect(filtering.filter(new FilterData()).filteredItems.length).toBe(1);
+
+        expect(filtering.filter(createFilterData({
+            'color': ['red'],
+        })).filteredItems.length).toBe(1);
+
+        expect(filtering.filter(createFilterData({
+            'color': ['blue'],
+        })).filteredItems.length).toBe(0);
+    });
+
+    test('Filtering Item with filter not in any group.', function () {
+        const schema = jsToSchema({
+            groups: {
+                color: ['red', 'blue'],
+            },
+            items: [{
+                name: 'item-1',
+                groups: {
+                    color: [green],
+                },
+            }],
+        });
+        const filtering = new Filtering(schema);
+
+        expect(filtering.filter(new FilterData()).filteredItems.length).toBe(1);
+
+        expect(filtering.filter(createFilterData({
+            'color': ['red'],
+        })).filteredItems.length).toBe(0);
     });
 });

--- a/src/result.ts
+++ b/src/result.ts
@@ -62,7 +62,7 @@ export class Result {
         this.#filteredItems.add(item);
         for (const groupName of item.getGroupNames()) {
             const groupResult = this.#groups.get(groupName);
-            groupResult.addFilteredItem(item);
+            groupResult?.addFilteredItem(item);
         }
     }
 
@@ -83,7 +83,7 @@ export class Result {
         this.#allItems.add(item);
         for (const groupName of item.getGroupNames()) {
             const groupResult = this.#groups.get(groupName);
-            groupResult.addAllItem(item);
+            groupResult?.addAllItem(item);
         }
     }
 }


### PR DESCRIPTION
Even though an error is nice to immediately hint an developer that there is something wrong with the setup, it's even more important to still function. If code for printing items is reused in multiple places but different groups/level of filtering is needed, an error would complicate the whole situation for the developer.